### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,10 +89,6 @@ const config = {
                 label: 'Blog',
                 to: 'https://shardeum.org/blog',
               },
-              {
-                label: 'Languages',
-                to: 'https://shardeum.org/languages',
-              },
             ],
           },
           {


### PR DESCRIPTION
Removed "Languages" in the footer under the General section.

Reason:- Error 404 