### PR TITLE
Blockchain TPS edits

### DIFF
--- a/docs/introduction/faqs/general.md
+++ b/docs/introduction/faqs/general.md
@@ -115,7 +115,7 @@ Unlike static state sharding where all the nodes in a shard cover the same addre
 | Smart Contract Language  | Solidity, Vyper                          | Solidity, Vyper                          | Rust                                     | C, C++, C#, Rust                        |
 | Explorer                 | EtherScan-like                           | Custom                                   | Custom                                   | Custom                                   |
 | Tx Fees in $             | Very Low & Constant                      | 0.000001                                 | 0.00044                                  | 0.005                                     | 
-| Txs Per Second (TPS)     | 1 per node (100k nodes @ 100k nodes      | 2k per shard (8k TPS @ 4 Shards)         | 10 per shard (100k TPS @10 shards)       | 5k per shard (15k TPS @15 shards       |
+| Txs Per Second (TPS)     | 1 per node (100k TPS @ 100k nodes)      | 2k per shard (8k TPS @ 4 shards)         | 10k per shard (100k TPS @10 shards)       | 3.75k per shard (15k TPS @ 4 shards)       |
 | Nodes per Shard          | 128                                      | 250                                      | 100                                      | 800                                       |
 | Latency                  | 10 Sec always for EIP2930 txs            | 10 Sec per involved shard                | 10 Sec per involved shard                | 10 Sec per involved shard              |
 | Consensus Algorithm      | PoQ + PoS                                | FBFT                                     | PBFT                                     | SPoS                                     |


### PR DESCRIPTION
Updated: 
-"TPS" instead of "nodes" for units
-Matched "shards" punctuation 
-Corrected TPS math based on sources:
-https://docs.elrond.com/welcome/welcome-to-elrond/
-https://decrypt.co/resources/what-is-near-protocol
