### PR TITLE
Fix Incorrect TIMESTAMP Opcode Description in Shardeum Opcodes Documentation

### DIFF
--- a/docs/introduction/opcodes.md
+++ b/docs/introduction/opcodes.md
@@ -20,7 +20,7 @@ Shardeum exposes block-related public API endpoints so JSON RPC servers can use 
 |-----------	|------------	|---------------	|----------------------------------------------------------------------------------------------------------------------------------	|
 | 40        	| BLOCKHASH  	| Supported     	| Hash of the specific block, only valid for the 256 most recent blocks, excluding the current one                                 	|
 | 41        	| COINBASE   	| Supported     	| Return network account address because there is no block miner in Shardeum                                                       	|
-| 42        	| TIMESTAMP  	| Supported     	| Return network account address because there is no block miner in Shardeum                                                       	|
+| 42        	| TIMESTAMP  	| Supported     	| Returns the timestamp of the current block in seconds since the Unix epoch.                                                       	|
 | 43        	| NUMBER     	| Supported     	| Current block's number                                                                                                           	|
 | 44        	| DIFFICULTY 	| Supported     	| Current block's difficulty. Since Shardeum does not use Proof of Work for transaction consensus the difficulty value is set to 0 	|
 | 45        	| GASLIMIT   	| Supported     	| Current block's gas limit                                                                                                        	|


### PR DESCRIPTION
I've come across an unusual error in the Shardeum Opcodes documentation. The description for the `TIMESTAMP` opcode, intriguingly, matches that of `COINBASE`, which seems like an oversight.

The current description states that `TIMESTAMP` returns the network account address, which is clearly more applicable to `COINBASE`. This seems to be a mix-up.

I propose a correction to accurately reflect the function of the `TIMESTAMP` opcode. A more appropriate description would be something like "Returns the timestamp of the current block," .

I've already made the necessary changes in the documentation and submitted this pull request for your review.

Thank you for your attention to this matter, and I look forward to your feedback or any further modifications you might suggest.