### PR TITLE
#275 Add section for running validator on Spheron

### DIFF
--- a/docs/node/run/hosted-deployment.md
+++ b/docs/node/run/hosted-deployment.md
@@ -8,7 +8,8 @@ sidebar_position: 4
 1. Sign up for a [Spheron account](https://app.spheron.network/#/signup)
 2. Navigate to our [Shardeum Testnet Validator Template](https://app.spheron.network/#/compute/marketplace?template=Shardeum%20Testnet%20Validator) on our Marketplace.
 3. Click the "Use Template" button and Spheron will auto-configure the settings you need to deploy a Shardeum Testnet Validator.
-4. You can change the region that your instance will deploy to if desired.
+4. Change the region that your instance will deploy to if desired.
+5. Be sure to set your password then click "Deploy"
 
 ## Customize the Node Settings
 
@@ -18,11 +19,6 @@ Check out this [Spheron article for details on this process with screenshots](ht
 
 ### Update Instance Settings
 
-We need to update the `SERVERIP` and `LOCALLANIP` based on your deployed region:
-- us-east -> `23.154.136.78`
-- us-west -> `23.158.200.193`
-- eu-east -> `5.199.170.42`
-
 On the Port Policy Info section of the instance dashboard, you will find mappings between Internal and External ports.
 
 Grab the external port mappings that map to internal ports 9001 and 10001.
@@ -30,23 +26,10 @@ Grab the external port mappings that map to internal ports 9001 and 10001.
 Click the "Settings" tab then click the "Update Instance" button.
 
 In the "Template Configuration" section update the following parameters:
-- `SERVERIP`:  _(Host IP based on deployed region)_
-- `LOCALLANIP`:  _(Host IP based on deployed region)_
 - `SHMEXT`:  _External Port mapped to internal port 9001_
 - `SHMINT`:  _External Port mapped to internal port 10001_
 
 Then click update.
-
-### Update GUI Password
-
-The Marketplace App sets a default password that you need to update.
-
-Navigate to the “Shell” tab on your Spheron instance page:
-
-Then enter the following and click “Enter”:
-```
-operator-cli gui set password YOUR_PASSWORD_HERE
-```
 
 ### Access Validator GUI
 

--- a/docs/node/run/hosted-deployment.md
+++ b/docs/node/run/hosted-deployment.md
@@ -14,18 +14,14 @@ sidebar_position: 4
 
 Now to stake and activate your validator, we have to manually update a couple of things specific to your instance.
 
-### Lookup IP of Host
-
-Go to your instance dashboard, grab your Connection URL in the format:  `provider.us-east.spheron.wiki`
-
-Then open a console and ping that host name to get the IP:
-```
-ping provider.us-east.spheron.wiki
-```
-
-Save that IP for the next step.
+Check out this [Spheron article for details on this process with screenshots](https://blog.spheron.network/deploy-and-stake-a-shardeum-validator-on-spheron-in-minutes) and additional context.
 
 ### Update Instance Settings
+
+We need to update the `SERVERIP` and `LOCALLANIP` based on your deployed region:
+- us-east -> `23.154.136.78`
+- us-west -> `23.158.200.193`
+- eu-east -> `5.199.170.42`
 
 On the Port Policy Info section of the instance dashboard, you will find mappings between Internal and External ports.
 
@@ -34,20 +30,20 @@ Grab the external port mappings that map to internal ports 9001 and 10001.
 Click the "Settings" tab then click the "Update Instance" button.
 
 In the "Template Configuration" section update the following parameters:
-- SERVERIP:  _(Host IP from the last step)_
-- LOCALLANIP:  _(Host IP from the last step)_
-- SHMEXT:  _External Port mapped to internal port 9001_
-- SHMINT:  _External Port mapped to internal port 10001_
+- `SERVERIP`:  _(Host IP based on deployed region)_
+- `LOCALLANIP`:  _(Host IP based on deployed region)_
+- `SHMEXT`:  _External Port mapped to internal port 9001_
+- `SHMINT`:  _External Port mapped to internal port 10001_
 
 Then click update.
 
 ### Update GUI Password
 
-The marketplace app sets a default password that you need to update.
+The Marketplace App sets a default password that you need to update.
 
 Navigate to the “Shell” tab on your Spheron instance page:
 
-Then enter the following and click “Run Command”:
+Then enter the following and click “Enter”:
 ```
 operator-cli gui set password YOUR_PASSWORD_HERE
 ```

--- a/docs/node/run/hosted-deployment.md
+++ b/docs/node/run/hosted-deployment.md
@@ -1,0 +1,68 @@
+---
+title: Hosted Deployment
+sidebar_position: 4
+---
+
+# Deploy a Validator Node Instance to Spheron
+
+1. Sign up for a [Spheron account](https://app.spheron.network/#/signup)
+2. Navigate to our [Shardeum Testnet Validator Template](https://app.spheron.network/#/compute/marketplace?template=Shardeum%20Testnet%20Validator) on our Marketplace.
+3. Click the "Use Template" button and Spheron will auto-configure the settings you need to deploy a Shardeum Testnet Validator.
+4. You can change the region that your instance will deploy to if desired.
+
+## Customize the Node Settings
+
+Now to stake and activate your validator, we have to manually update a couple of things specific to your instance.
+
+### Lookup IP of Host
+
+Go to your instance dashboard, grab your Connection URL in the format:  `provider.us-east.spheron.wiki`
+
+Then open a console and ping that host name to get the IP:
+```
+ping provider.us-east.spheron.wiki
+```
+
+Save that IP for the next step.
+
+### Update Instance Settings
+
+On the Port Policy Info section of the instance dashboard, you will find mappings between Internal and External ports.
+
+Grab the external port mappings that map to internal ports 9001 and 10001.
+
+Click the "Settings" tab then click the "Update Instance" button.
+
+In the "Template Configuration" section update the following parameters:
+- SERVERIP:  _(Host IP from the last step)_
+- LOCALLANIP:  _(Host IP from the last step)_
+- SHMEXT:  _External Port mapped to internal port 9001_
+- SHMINT:  _External Port mapped to internal port 10001_
+
+Then click update.
+
+### Update GUI Password
+
+The marketplace app sets a default password that you need to update.
+
+Navigate to the “Shell” tab on your Spheron instance page:
+
+Then enter the following and click “Run Command”:
+```
+operator-cli gui set password YOUR_PASSWORD_HERE
+```
+
+### Access Validator GUI
+
+On your instance dashboard, grab your Connection URL which maps from the internal port, 8080.
+
+Example:  `provider.us-west.spheron.wiki:32003`
+
+Then append `https://` to the connection URL and enter it into your browser.
+
+Example:  https://provider.us-west.spheron.wiki:32003/
+
+From this point you can follow the standard steps to connect your wallet and stake SHM to your validator 
+detailed here on the [Run Validator page](https://docs.shardeum.org/node/run/validator#step-5-start-validator)
+
+


### PR DESCRIPTION
**Description:** Updates to [https://github.com/availproject/availproject.github.io/blob/main/docs/operate/deployment-options.md page](https://github.com/Shardeum/shardeum-docs/tree/master/docs/node/run)

- Add links to deploy validator node to Spheron in a couple minutes
- Add additional steps to stake and activate validator node

**Issue:** #275 

Contact: [chris@spheron.network](mailto:chris@spheron.network)

**Ran changes locally to verify:**

http://localhost:8000/node/run/hosted-deployment

![image](https://github.com/Shardeum/shardeum-docs/assets/4750426/d1f5e2eb-59f1-4b88-b550-d10d2995ecb9)


