### PR TITLE
Update foundry.md

### DIFF
--- a/docs/smart-contracts/deploy/foundry.md
+++ b/docs/smart-contracts/deploy/foundry.md
@@ -19,10 +19,6 @@ https://www.paradigm.xyz/2021/12/introducing-the-foundry-ethereum-development-to
 
 1. Install
 
-```
-foundryup
-```
-
 with the Foundry toolchain installer:
 
 <Tabs>


### PR DESCRIPTION
Not sure if this is intentional, but it seemed confusing to me.

Removed missplaced `foundryup` command, the right order is to use the installer command and then run `foundryup`.