### PR TITLE
fix: code errors 

### DIFF
--- a/content/docs/architecture/apis-and-interfaces.mdx
+++ b/content/docs/architecture/apis-and-interfaces.mdx
@@ -115,8 +115,8 @@ Reading smart contract events can also be done using Shardeum cycles (we listen 
     **JSON URL Filter Variables**
 
     ```
-    ?startCycle=lastestCycle
-    &endCycle=lastestCycle
+    ?startCycle=latestCycle
+    &endCycle=latestCycle
     &address=addressToListenTo
     &page=1
     ```

--- a/content/docs/architecture/consensus-and-sharding-mechanism.mdx
+++ b/content/docs/architecture/consensus-and-sharding-mechanism.mdx
@@ -12,7 +12,7 @@ Shardeum's approach to consensus and sharding involves complex mechanisms to ens
 * The Shardeum network utilizes a trustless consensus system where nodes must agree on the data before it becomes part of the next cycle.
 * This process uses advanced algorithms to ensure that all nodes reach a consensus on the transaction records.
 * Each node generates cycle records, akin to traditional blockchain blocks but are unique to Shardeum's structure.
-* Here you can take a deep dive into the [consensus algorithms used by Shardeum](/docs/faqs/glossary#proof-of-stake-pos) and [Proof of Quorum](/docs/faqs/glossary#proof-of-quorum-poq)", focusing on their design and implementation.
+* Here you can take a deep dive into the [consensus algorithms used by Shardeum](/docs/faqs/glossary#proof-of-stake-pos) and [Proof of Quorum](/docs/faqs/glossary#proof-of-quorum-poq), focusing on their design and implementation.
 
 ### **2. Node Lifecycle Management:**
 


### PR DESCRIPTION
Updated the documentation by replacing the parameter &endCycle=lastestCycle with &endCycle=latestCycle. The incorrect spelling "lastestCycle" can cause errors when filtering API requests because the parameter "latestCycle" will not be recognized correctly.

Closes #17 